### PR TITLE
produce maven artifacts in library/build/mvn-repo/

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'maven'
 
 android {
     compileSdkVersion 19
@@ -13,4 +14,31 @@ android {
 
 dependencies {
     compile 'com.android.support:support-v4:20.0.0'
+}
+uploadArchives {
+    repositories.mavenDeployer {
+        repository(url: "file:///${project.buildDir}/mvn-repo")
+
+        pom.groupId     = 'com.tech.freak'
+        pom.artifactId  = 'wizardpager'
+        pom.version     = '1.0'
+        pom.packaging   = 'aar'
+
+        pom.project {
+            url 'https://github.com/TechFreak/WizardPager'
+            licenses {
+                license {
+                    name 'Apache License, Version 2.0'
+                    url 'http://www.apache.org/licenses/LICENSE-2.0'
+                }
+            }
+            developers {
+                developer {
+                    id 'TechFreak'
+                    name 'Tech Freak'
+                    email 'tech.freak.blog@gmail.com'
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
I modified library/build.gradle to produce maven artifacts in library/build/mvn-repo/, hoping this helps with #2. If you're opposed to the idea of publishing on Maven Central please consider publishing to github by creating a separate repository or special-case branch for the maven artifact. For an example of hosting maven artifacts on github please see: https://github.com/WhisperSystems/maven

This pull also makes it easy for users to package and publish their own artifact of the project but personally I would prefer to use something packaged by the author :) thanks for the great project
